### PR TITLE
added opening and closing store hours in database

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,0 @@
-PORT=8000
-DATABASE_URL=postgres://docker:docker@127.0.0.1:5400/api-dev
-OKTA_URL_ISSUER=https://example.okta.com/oauth2/default
-OKTA_CLIENT_ID=example

--- a/data/migrations/20201109234734_seller_profie_and_item.js
+++ b/data/migrations/20201109234734_seller_profie_and_item.js
@@ -6,6 +6,8 @@ exports.up = function (knex) {
       tb.string('email_address', 255);
       tb.string('phone_number', 255);
       tb.string('physical_address', 255);
+      tb.time('open_time');
+      tb.time('closing_time');
       tb.text('description');
     })
     .createTable('category', (tb) => {

--- a/data/seeds/02_seller_profiles.js
+++ b/data/seeds/02_seller_profiles.js
@@ -7,6 +7,8 @@ exports.seed = function (knex) {
       email_address: 'llama001@maildrop.cc',
       phone_number: '(555) 444-3333',
       physical_address: '100 Davidson Street, Maine',
+      open_time: '9:00',
+      closing_time: '16:30',
       description: 'Rugs, Rugs, Rugs! Discount Rugs, Fine Rugs, Bathroom Rugs!',
     },
 
@@ -16,6 +18,8 @@ exports.seed = function (knex) {
       email_address: 'llama002@maildrop.cc',
       phone_number: '(555) 123-4567',
       physical_address: '35 Sampsonite Avenue, Lingdon Nevada, 22556',
+      open_time: '4:20',
+      closing_time: '14:15',
       description:
         'Selling my personal Junk: Hawaiian shirts, mixed ammunition, unmatched fine china.',
     },
@@ -26,6 +30,8 @@ exports.seed = function (knex) {
       email_address: 'llama003@maildrop.cc',
       phone_number: '(555) 987-6543',
       physical_address: '1378 California Drive, California, 00012',
+      open_time: '12:00',
+      closing_time: '20:00',
       description: 'Books, Rockets, Washington News Media',
     },
   ]);


### PR DESCRIPTION
Added hours of operation for opening and closing of stores in database. Shape of data would now look like:
{
      id: '00ulthapbErVUwVJy4x6',
      seller_name: 'SuperStore Rug Emporium',
      email_address: 'llama001@maildrop.cc',
      phone_number: '(555) 444-3333',
      physical_address: '100 Davidson Street, Maine',
      open_time: '9:00',
      closing_time: '16:30',
      description: 'Rugs, Rugs, Rugs! Discount Rugs, Fine Rugs, Bathroom Rugs!',
    }